### PR TITLE
Validation schema bug

### DIFF
--- a/components/onboarding/Accuracy.js
+++ b/components/onboarding/Accuracy.js
@@ -30,5 +30,6 @@ const Accuracy = ({ incrementPage }) => (
 
 Accuracy.hideNext = true
 Accuracy.progressImg = progress3
+Accuracy.componentName = "Accuracy"
 
 export default Accuracy

--- a/components/onboarding/Confirmation.js
+++ b/components/onboarding/Confirmation.js
@@ -26,5 +26,6 @@ const Confirmation = () => {
 Confirmation.hideNext = true
 Confirmation.hidePrevious = true
 Confirmation.progressImg = progress5
+Confirmation.componentName = "Confirmation"
 
 export default Confirmation

--- a/components/onboarding/Contact.js
+++ b/components/onboarding/Contact.js
@@ -82,5 +82,6 @@ const Contact = () => (
 
 Contact.validationSchema = validation
 Contact.progressImg = progress4
+Contact.componentName = "Contact"
 
 export default Contact

--- a/components/onboarding/Eligibility.js
+++ b/components/onboarding/Eligibility.js
@@ -105,5 +105,6 @@ const Eligibility = ({
 
 Eligibility.validationSchema = validation
 Eligibility.progressImg = progress1
+Eligibility.componentName = "Eligibility"
 
 export default Eligibility

--- a/components/onboarding/Loan.js
+++ b/components/onboarding/Loan.js
@@ -116,5 +116,6 @@ const Loan = ({
 
 Loan.validationSchema = validation
 Loan.progressImg = progress2
+Loan.componentName = "Loan"
 
 export default Loan

--- a/components/onboarding/Personal.js
+++ b/components/onboarding/Personal.js
@@ -69,5 +69,6 @@ const Personal = ({ values: { dob } }) => (
 
 Personal.validationSchema = validation
 Personal.progressImg = progress3
+Personal.componentName = "Personal"
 
 export default Personal

--- a/components/onboarding/Salary.js
+++ b/components/onboarding/Salary.js
@@ -28,5 +28,6 @@ const Salary = () => (
 
 Salary.validationSchema = validation
 Salary.progressImg = progress2
+Salary.componentName = "Salary"
 
 export default Salary

--- a/components/onboarding/Summary.js
+++ b/components/onboarding/Summary.js
@@ -140,5 +140,6 @@ const Summary = ({ values, setPage }) => {
 }
 
 Summary.progressImg = progress4
+Summary.componentName = "Summary"
 
 export default Summary

--- a/components/onboarding/Verification.js
+++ b/components/onboarding/Verification.js
@@ -37,5 +37,6 @@ const Verification = ({ emailVerificationError }) => (
 
 Verification.validationSchema = validation
 Verification.progressImg = progress1
+Verification.componentName = "Verification"
 
 export default Verification

--- a/components/onboarding/Welcome.js
+++ b/components/onboarding/Welcome.js
@@ -28,6 +28,6 @@ const Welcome = ({ incrementPage, employer }) => (
 
 Welcome.hideControls = true
 Welcome.progressImg = progress1
-Welcome.trueName = "Welcome"
+Welcome.componentName = "Welcome"
 
 export default Welcome

--- a/components/onboarding/Welcome.js
+++ b/components/onboarding/Welcome.js
@@ -28,5 +28,6 @@ const Welcome = ({ incrementPage, employer }) => (
 
 Welcome.hideControls = true
 Welcome.progressImg = progress1
+Welcome.trueName = "Welcome"
 
 export default Welcome

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -224,20 +224,19 @@ const Wizard = ({ children, employer }) => {
   const [emailVerificationError, setEmailVerificationError] = useState(false)
 
   const steps = React.Children.toArray(children)
-  const pages = steps.map(step => step.type.name)
+  const pages = steps.map(step => step.type.componentName)
   const activePage = R.find(R.pathEq(["type", "componentName"], page))(steps)
 
   console.log("activePage", activePage)
   console.log("steps", steps)
 
   const {
-    validationSchema = {},
+    validationSchema,
     hideNext,
     hidePrevious,
     progressImg,
     hideControls,
   } = activePage && activePage.type
-  console.log("validationSchema", validationSchema)
 
   const incrementPage = () => {
     const pageIndex = R.findIndex(R.equals(page))(pages)
@@ -255,7 +254,7 @@ const Wizard = ({ children, employer }) => {
     <Formik
       {...{
         initialValues,
-        validationSchema: validationSchema || {},
+        validationSchema,
         onSubmit: onSubmit({ incrementPage, employer }),
         enableReinitialize: false,
       }}

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -234,6 +234,7 @@ const Wizard = ({ children, employer }) => {
     progressImg,
     hideControls,
   } = activePage && activePage.type
+  console.log("validationSchema", validationSchema)
 
   const incrementPage = () => {
     const pageIndex = R.findIndex(R.equals(page))(pages)

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -266,7 +266,7 @@ const Wizard = ({ children, employer }) => {
         setTouched,
         setFieldValue,
       }) => {
-        const debugging = false
+        const debugging = true
 
         return (
           <Container>

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -227,6 +227,8 @@ const Wizard = ({ children, employer }) => {
   const pages = steps.map(step => step.type.name)
   const activePage = R.find(R.pathEq(["type", "name"], page))(steps)
 
+  console.log("activePage", activePage)
+
   const {
     validationSchema = {},
     hideNext,

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -228,7 +228,7 @@ const Wizard = ({ children, employer }) => {
   const activePage = R.find(R.pathEq(["type", "name"], page))(steps)
 
   const {
-    validationSchema,
+    validationSchema = {},
     hideNext,
     hidePrevious,
     progressImg,

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -251,7 +251,7 @@ const Wizard = ({ children, employer }) => {
     <Formik
       {...{
         initialValues,
-        validationSchema,
+        validationSchema: validationSchema || {},
         onSubmit: onSubmit({ incrementPage, employer }),
         enableReinitialize: false,
       }}

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -225,7 +225,7 @@ const Wizard = ({ children, employer }) => {
 
   const steps = React.Children.toArray(children)
   const pages = steps.map(step => step.type.name)
-  const activePage = R.find(R.pathEq(["type", "name"], page))(steps)
+  const activePage = R.find(R.pathEq(["type", "componentName"], page))(steps)
 
   console.log("activePage", activePage)
   console.log("steps", steps)

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -227,9 +227,6 @@ const Wizard = ({ children, employer }) => {
   const pages = steps.map(step => step.type.componentName)
   const activePage = R.find(R.pathEq(["type", "componentName"], page))(steps)
 
-  console.log("activePage", activePage)
-  console.log("steps", steps)
-
   const {
     validationSchema,
     hideNext,
@@ -268,7 +265,7 @@ const Wizard = ({ children, employer }) => {
         setTouched,
         setFieldValue,
       }) => {
-        const debugging = true
+        const debugging = false
 
         return (
           <Container>

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -228,6 +228,7 @@ const Wizard = ({ children, employer }) => {
   const activePage = R.find(R.pathEq(["type", "name"], page))(steps)
 
   console.log("activePage", activePage)
+  console.log("steps", steps)
 
   const {
     validationSchema = {},


### PR DESCRIPTION
The component, in production, when it's minified I think, changes its name presumably to take up less characters. Lookie:

```
  const pages = steps.map(step => step.type.name)
  const activePage = R.find(R.pathEq(["type", "name"], page))(steps)
```
type.name, which is I think a react thing, changes from the name of the component to a single character. I have explicitly set a componentName property on onboarding screens now, which get read by these pages instead of name, and they persist in the production build.